### PR TITLE
Made MCQs interactive

### DIFF
--- a/src/components/python-pages/Lesson.js
+++ b/src/components/python-pages/Lesson.js
@@ -28,18 +28,18 @@ class Lesson extends React.Component {
 
   attachEventListeners() {
     const options = document.querySelectorAll("li");
-    for (let i = 3; i < options.length; i++) {
+    for (let i = 0; i < options.length; i++) {
       let option = options[i];
-      if (option.parentElement.style.listStyleType == "upper-alpha") {
-        if (option.id == "correct") {
-          option.addEventListener("click", () => {
-            option.classList.add("correct");
-          });
-        } else {
-          option.addEventListener("click", () => {
-            option.classList.add("incorrect");
-          });
-        }
+      if (option.id == "correct") {
+        option.style.cursor = "pointer";
+        option.addEventListener("click", () => {
+          option.classList.add("correct");
+        });
+      } else if (option.id == "incorrect") {
+        option.style.cursor = "pointer";
+        option.addEventListener("click", () => {
+          option.classList.add("incorrect");
+        });
       }
     };
   }

--- a/src/components/python-pages/Lesson.js
+++ b/src/components/python-pages/Lesson.js
@@ -20,11 +20,29 @@ class Lesson extends React.Component {
     )
       .then((response) => response.json())
       .then((data) => {
-        this.setState({ lesson: data });
+        this.setState({ lesson: data }, () => {
+          this.attachEventListeners();
+        });
       });
   }
 
-
+  attachEventListeners() {
+    const options = document.querySelectorAll("li");
+    for (let i = 3; i < options.length; i++) {
+      let option = options[i];
+      if (option.parentElement.style.listStyleType == "upper-alpha") {
+        if (option.id == "correct") {
+          option.addEventListener("click", () => {
+            option.classList.add("correct");
+          });
+        } else {
+          option.addEventListener("click", () => {
+            option.classList.add("incorrect");
+          });
+        }
+      }
+    };
+  }
 
     setClassNamesToHTML = (content) => {
         const { lesson } = this.state;

--- a/src/index.css
+++ b/src/index.css
@@ -247,6 +247,14 @@ a:hover {
   }
 }
 
+.correct {
+ color: #009924;
+}
+
+.incorrect {
+  color: #cb0000;
+}
+
 /* Fractions */
 
 .frac {


### PR DESCRIPTION
Made the multiple choice questions interactive. To use this feature, use the following convention:

1. Set the questions to a numbered list so that there is a number next to the question.
2. Set the answer choices indented under the questions to be an upper-case letter list.
3. Select the correct answer by setting the id of the correct answer of the `<li>` to "correct"
4. Select the incorrect answer by setting the id of the incorrect answer of the `<li>` to "incorrect"

Example:
![image](https://github.com/YomenT/bluebird-teaching-frontend/assets/94801110/501a22b3-1bec-4638-a13c-941cecd7cc6c)
![image](https://github.com/YomenT/bluebird-teaching-frontend/assets/94801110/bd8c75ce-c232-4bd4-9891-3ace4453a745)