### PR TITLE
Updated to show lessons that are in progress

### DIFF
--- a/src/components/python-pages/Lesson.js
+++ b/src/components/python-pages/Lesson.js
@@ -113,11 +113,21 @@ const Lesson = (props) => {
             {showDropdown && (
               <div ref={dropdownRef} className="dropdown-content">
                 <Link to={`/${subset}`}>All Lessons</Link>
-                {lessonList.map((lessons, index) => (
-                  <Link key={lessons.id} to={`/${subset}/${index + 1}`}>
-                    {lessons.title}
-                  </Link>
-                ))}
+                {lessonList.map((lessons, index) => {
+                  if (lessons.completed) {
+                    return (
+                      <Link key={lessons.id} to={`/${subset}/${index + 1}`}>
+                        {lessons.title}
+                      </Link>
+                    )
+                  } else {
+                    return (
+                      <div style={{"color": "lightgray"}}>
+                        {lessons.title + " - In Progress"}
+                      </div>
+                    )
+                  }
+                  })}
               </div>
             )}
           </button>

--- a/src/components/python-pages/PythonLinkOutline.js
+++ b/src/components/python-pages/PythonLinkOutline.js
@@ -33,13 +33,23 @@ class PythonLinkOutline extends React.Component {
             <div>
                 <ol className="list-medium">
                     {/* <li><Link to="/python/introduction" style={{ color: "#365789" }} onMouseOver={this.changeLinkColorEnter} onMouseOut={this.changeLinkColorLeave}>How To Code In Python</Link></li> */}
-                    {lessons.map((lesson, index)  => (
-                        <li key={index}>
-                            <Link to={`/${lesson.subset_name}/${index + 1}/`} style={{ color: '#365789' }} onMouseOver={this.changeLinkColorEnter} onMouseOut={this.changeLinkColorLeave}>
-                            {lesson.title}
-                            </Link>
-                        </li>
-                    ))}
+                    {lessons.map((lesson, index)  => {
+                        if (lesson.completed) {
+                            return (
+                            <li key={index}>
+                                <Link to={`/${lesson.subset_name}/${index + 1}/`} style={{ color: '#365789' }} onMouseOver={this.changeLinkColorEnter} onMouseOut={this.changeLinkColorLeave}>
+                                {lesson.title}
+                                </Link>
+                            </li>
+                            )
+                        } else {
+                            return (
+                            <li key={index} style={{"color": "#728fab"}}>
+                                {lesson.title + " - In Progress"}
+                            </li>
+                            )
+                        }
+                    })}
                 </ol>
             </div>
         )


### PR DESCRIPTION
Updated rendering of lessons to identify if a lesson is in progress. If so, the lesson is grayed out, unclickable, and says "In Progress." Additionally, the same effect is applied to the navigation menu dropdown within the lessons page.